### PR TITLE
fix: wheel install must not be inside venv

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -13,9 +13,7 @@ export ZOPEN_RUNTIME_DEPS='python'
 
 export ZOPEN_CATEGORIES='development devops'
 
-if [ -z "$ZOPEN_COMP" ]; then
-    export ZOPEN_COMP='python'
-fi
+export ZOPEN_COMP='skip'
 
 if [ -z "$ZOPEN_CHECK" ]; then
   export ZOPEN_CHECK='zopen_check'
@@ -33,14 +31,14 @@ zopen_build() {
     python -m venv .venv
     . .venv/bin/activate
     pip install setuptools build installer wheel && \
-    pip install -e . && \
-    rm -r dist && \
+    rm -rf dist && \
     python -m build --wheel
+    zopen_build_result="$?"
     deactivate
+    return "$zopen_build_result"
 }
 
 zopen_check() {
-    echo $@
     . .venv/bin/activate
     pip install -r conans/requirements.txt
     pip install -r conans/requirements_server.txt
@@ -69,13 +67,13 @@ zopen_check_results() {
 }
 
 zopen_get_version() {
-    "${ZOPEN_INSTALL_DIR}/bin/conan" --version | sed 's/Conan version //'
+    echo "${CONAN_VERSION}"
 }
 
 zopen_install() {
-    . .venv/bin/activate
-    python -m installer --destdir="${ZOPEN_INSTALL_DIR}" --prefix='' dist/*.whl && \
-    chtag -tc iso8859-1 "${ZOPEN_INSTALL_DIR}/bin/conan" && \
+    set -e
+    mkdir -p "${ZOPEN_INSTALL_DIR}/lib/"
+    python -m pip install --prefix="${ZOPEN_INSTALL_DIR}" dist/*.whl
     cp dist/*.whl "${ZOPEN_INSTALL_DIR}/lib/"
-    deactivate
+    set +e
 }


### PR DESCRIPTION
Fixes the install of the wheel to use the system pip outside of the python virtual environment. However, this does lead to the issue that we need some way to set the python module path. 

ie.
```
~/projects/conanport %conan --version
Traceback (most recent call last):
  File "/u/aidanp/zopen/usr/local/bin/conan", line 5, in <module>
    from conans.conan import run
ModuleNotFoundError: No module named 'conans'
~/projects/conanport %PYTHONPATH=~/zopen/usr/local/lib/python3.12/site-packages/ conan --version
Conan version 2.6.0
```

Also depends on [meta#878](https://github.com/ZOSOpenTools/meta/pull/858).