### PR TITLE
Use zopen_append_to_setup and zopen_append_to_env

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -73,7 +73,19 @@ zopen_get_version() {
 zopen_install() {
     set -e
     mkdir -p "${ZOPEN_INSTALL_DIR}/lib/"
-    python -m pip install --prefix="${ZOPEN_INSTALL_DIR}" dist/*.whl
-    cp dist/*.whl "${ZOPEN_INSTALL_DIR}/lib/"
+    cp "dist/conan-${CONAN_VERSION}-py3-none-any.whl" "${ZOPEN_INSTALL_DIR}/lib/"
+    mkdir -p "${ZOPEN_INSTALL_DIR}/bin/"
+    touch "${ZOPEN_INSTALL_DIR}/bin/conan"
     set +e
+}
+
+zopen_append_to_setup() {
+    echo "python -m pip install --prefix=. 'lib/conan-${CONAN_VERSION}-py3-none-any.whl'"
+}
+
+zopen_append_to_env() {
+    cat <<EOF
+PYTHONPATH="\$PYTHONPATH:\$(python -c 'import site; import os; site.PREFIXES=[os.getcwd()]; print(site.getsitepackages()[0])')"
+export PYTHONPATH="\$(deleteDuplicateEntries "\$PYTHONPATH" ":")"
+EOF
 }


### PR DESCRIPTION
Same change as https://github.com/zopencommunity/mesonport/pull/7

Uses `zopen_append_to_setup` to run `pip install` on the installer machine rather than on the build machine. This ensures that the install is done using the correct pip and python versions.

Uses `zopen_append_to_env` to set `PYTHONPATH` to the site-packages directory created by pip.